### PR TITLE
fix: params for auth needed in request body

### DIFF
--- a/future_usdt_perpetual.go
+++ b/future_usdt_perpetual.go
@@ -143,8 +143,8 @@ type CreateLinearOrderParam struct {
 	Price       *float64         `json:"price,omitempty"`
 	TakeProfit  *float64         `json:"take_profit,omitempty"`
 	StopLoss    *float64         `json:"stop_loss,omitempty"`
-	TpTriggerBy *TriggerByFuture `json:"tp_trigger_by"`
-	SlTriggerBy *TriggerByFuture `json:"sl_trigger_by"`
+	TpTriggerBy *TriggerByFuture `json:"tp_trigger_by,omitempty"`
+	SlTriggerBy *TriggerByFuture `json:"sl_trigger_by,omitempty"`
 	OrderLinkID *string          `json:"order_link_id,omitempty"`
 }
 


### PR DESCRIPTION
It may have became necessary to include params related to authentication in the request body.

Somehow, this has worked with query strings in the past.

fix: https://github.com/hirokisan/bybit/issues/58