### PR TITLE
Fix: Add 'position_idx' to CreateLinearOrderParam

### DIFF
--- a/future_usdt_perpetual.go
+++ b/future_usdt_perpetual.go
@@ -146,6 +146,7 @@ type CreateLinearOrderParam struct {
 	TpTriggerBy *TriggerByFuture `json:"tp_trigger_by,omitempty"`
 	SlTriggerBy *TriggerByFuture `json:"sl_trigger_by,omitempty"`
 	OrderLinkID *string          `json:"order_link_id,omitempty"`
+	PositionIdx *int             `json:"position_idx,omitempty"`
 }
 
 // CreateLinearOrder :


### PR DESCRIPTION
https://bybit-exchange.github.io/docs/futuresV2/linear/#t-placeactive

position_idx | false | integer | Position idx, used to identify positions in different position modes. Required if you are under One-Way Mode:0-One-Way Mode1-Buy side of both side mode2-Sell side of both side mode
-- | -- | -- | --
