### PR TITLE
Private Websocket Position V5

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,40 @@ svcRoot := wsClient.Spot().V1()
 wsClient.Start(context.Background(), executors)
 ```
 
+V5 usage
+```golang
+import "github.com/hirokisan/bybit/v2"
+
+wsClient := bybit.NewWebsocketClient().WithBaseURL("wss://stream-testnet.bybit.com").WithAuth("key", "secret")
+svc, err := wsClient.V5().Private()
+if err != nil {
+	// handle dialing error
+}
+
+err = svc.Subscribe()
+if err != nil {
+	// handle subscription error
+}
+
+err = svc.RegisterFuncPosition(func(position bybit.V5WebsocketPrivatePositionResponseContent) error {
+	// handle new position information
+})
+if err != nil {
+	// handle registration error
+}
+
+errHandler := func(isWebsocketClosed bool, err error) {
+	// Connection issue (timeout, etc.). 
+	
+	// At this point, the connection is dead and you must handle the reconnection yourself
+}
+
+err = svc.Start(errHandler, context.Background())
+if err != nil {
+	// handle reconnection (ping issue, etc.). Probably can be ignored as the errHandler would be notified too
+}
+```
+
 ## Implemented
 
 The following API endpoints have been implemented
@@ -270,6 +304,12 @@ The following API endpoints have been implemented
 - `/spot/v1/account` Get Wallet Balance
 
 ### WebSocket API
+
+#### [Private v5](https://bybit-exchange.github.io/docs/v5/websocket/private/position)
+
+##### Private Topics
+
+- Position
 
 #### [Spot v1](https://bybit-exchange.github.io/docs/spot/v1/#t-websocket)
 

--- a/v5_ws_private.go
+++ b/v5_ws_private.go
@@ -1,10 +1,256 @@
 package bybit
 
-// V5WebsocketPrivateServiceI :
-type V5WebsocketPrivateServiceI interface {
-}
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log"
+	"os"
+	"os/signal"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
 
 // V5WebsocketPrivateService :
 type V5WebsocketPrivateService struct {
-	client *WebSocketClient
+	client     *WebSocketClient
+	connection *websocket.Conn
+
+	paramPrivateMap map[V5WebsocketPrivateParamKey]func(V5WebsocketPrivatePositionResponseContent) error
+}
+
+const (
+	// V5WebsocketPrivatePath :
+	V5WebsocketPrivatePath = "/v5/private"
+)
+
+// V5WebsocketPrivateTopic :
+type V5WebsocketPrivateTopic string
+
+const (
+	// V5WebsocketPrivateTopicPosition :
+	V5WebsocketPrivateTopicPosition = "position"
+)
+
+// V5WebsocketPrivateParamKey :
+type V5WebsocketPrivateParamKey struct {
+	Topic V5WebsocketPrivateTopic
+}
+
+type V5WebsocketPrivatePositionResponseContent struct {
+	Id           string                                   `json:"id"`
+	Topic        V5WebsocketPrivateTopic                  `json:"topic"`
+	CreationTime int64                                    `json:"creationTime"`
+	Data         []V5WebsocketPrivatePositionResponseData `json:"data"`
+}
+
+// V5WebsocketPrivatePositionResponseData :
+type V5WebsocketPrivatePositionResponseData struct {
+	AutoAddMargin   int        `json:"autoAddMargin"`
+	PositionIdx     int        `json:"positionIdx"`
+	TpSlMode        TpSlMode   `json:"tpSlMode"`
+	TradeMode       int        `json:"tradeMode"`
+	RiskId          int        `json:"riskId"`
+	RiskLimitValue  string     `json:"riskLimitValue"`
+	Symbol          SymbolV5   `json:"symbol"`
+	Side            Side       `json:"side"`
+	Size            string     `json:"size"`
+	EntryPrice      string     `json:"entryPrice"`
+	Leverage        string     `json:"leverage"`
+	PositionValue   string     `json:"positionValue"`
+	MarkPrice       string     `json:"markPrice"`
+	PositionBalance string     `json:"positionBalance"`
+	PositionIM      string     `json:"positionIM"`
+	PositionMM      string     `json:"positionMM"`
+	TakeProfit      string     `json:"takeProfit"`
+	StopLoss        string     `json:"stopLoss"`
+	TrailingStop    string     `json:"trailingStop"`
+	UnrealisedPnl   string     `json:"unrealisedPnl"`
+	CumRealisedPnl  string     `json:"cumRealisedPnl"`
+	CreatedTime     string     `json:"CreatedTime"`
+	UpdatedTime     string     `json:"updatedTime"`
+	TpslMode        TpSlMode   `json:"tpslMode"`
+	LiqPrice        string     `json:"liqPrice"`
+	BustPrice       string     `json:"bustPrice"`
+	Category        CategoryV5 `json:"category"`
+	PositionStatus  string     `json:"positionStatus"`
+}
+
+// Key :
+func (r *V5WebsocketPrivatePositionResponseContent) Key() V5WebsocketPrivateParamKey {
+	return V5WebsocketPrivateParamKey{
+		Topic: r.Topic,
+	}
+}
+
+// addParamPositionFunc :
+func (s *V5WebsocketPrivateService) addParamPositionFunc(param V5WebsocketPrivateParamKey, f func(V5WebsocketPrivatePositionResponseContent) error) error {
+	if _, exist := s.paramPrivateMap[param]; exist {
+		return errors.New("already registered for this param")
+	}
+	s.paramPrivateMap[param] = f
+	return nil
+}
+
+// retrievePositionFunc :
+func (s *V5WebsocketPrivateService) retrievePositionFunc(key V5WebsocketPrivateParamKey) (func(V5WebsocketPrivatePositionResponseContent) error, error) {
+	f, exist := s.paramPrivateMap[key]
+	if !exist {
+		return nil, errors.New("func not found")
+	}
+	return f, nil
+}
+
+// judgeTopic :
+func (s *V5WebsocketPrivateService) judgeTopic(respBody []byte) (V5WebsocketPrivateTopic, error) {
+	parsedData := map[string]interface{}{}
+	if err := json.Unmarshal(respBody, &parsedData); err == nil {
+		if topic, ok := parsedData["topic"].(string); ok {
+			return V5WebsocketPrivateTopic(topic), nil
+		}
+		if authStatus, ok := parsedData["success"].(bool); ok {
+			if !authStatus {
+				return "", errors.New("auth failed: " + parsedData["ret_msg"].(string))
+			}
+		}
+		return "", nil
+	} else {
+		return "", err
+	}
+}
+
+// parseResponse :
+func (s *V5WebsocketPrivateService) parseResponse(respBody []byte, response interface{}) error {
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Subscribe :
+func (s *V5WebsocketPrivateService) Subscribe() error {
+	param, err := s.client.buildAuthParam()
+	if err != nil {
+		return err
+	}
+	if err := s.connection.WriteMessage(websocket.TextMessage, param); err != nil {
+		return err
+	}
+	return nil
+}
+
+// RegisterFuncPosition :
+func (s *V5WebsocketPrivateService) RegisterFuncPosition(f func(V5WebsocketPrivatePositionResponseContent) error) error {
+	key := V5WebsocketPrivateParamKey{
+		Topic: V5WebsocketPrivateTopicPosition,
+	}
+	if err := s.addParamPositionFunc(key, f); err != nil {
+		return err
+	}
+	param := struct {
+		Op   string        `json:"op"`
+		Args []interface{} `json:"args"`
+	}{
+		Op:   "subscribe",
+		Args: []interface{}{V5WebsocketPrivateTopicPosition},
+	}
+	buf, err := json.Marshal(param)
+	if err != nil {
+		return err
+	}
+	if err := s.connection.WriteMessage(websocket.TextMessage, buf); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Start :
+type ErrHandler func(isWebsocketClosed bool, err error)
+
+func (s *V5WebsocketPrivateService) Start(errHandler ErrHandler, ctx context.Context) error {
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for {
+			if err := s.Run(); err != nil {
+				errHandler(IsErrWebsocketClosed(err), err)
+				return
+			}
+		}
+	}()
+
+	ticker := time.NewTicker(20 * time.Second)
+	defer ticker.Stop()
+
+	ctx, stop := signal.NotifyContext(ctx, os.Interrupt)
+	defer stop()
+
+	for {
+		select {
+		case <-done:
+			return nil
+		case <-ticker.C:
+			if err := s.Ping(); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			log.Println("interrupt")
+
+			if err := s.Close(); err != nil {
+				return err
+			}
+			select {
+			case <-done:
+			case <-time.After(time.Second):
+			}
+			return nil
+		}
+	}
+}
+
+// Run :
+func (s *V5WebsocketPrivateService) Run() error {
+	_, message, err := s.connection.ReadMessage()
+	if err != nil {
+		return err
+	}
+
+	topic, err := s.judgeTopic(message)
+	if err != nil {
+		return err
+	}
+	switch topic {
+	case V5WebsocketPrivateTopicPosition:
+		var resp V5WebsocketPrivatePositionResponseContent
+		if err := s.parseResponse(message, &resp); err != nil {
+			return err
+		}
+		f, err := s.retrievePositionFunc(resp.Key())
+		if err != nil {
+			return err
+		}
+		if err := f(resp); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Ping :
+func (s *V5WebsocketPrivateService) Ping() error {
+	if err := s.connection.WriteMessage(websocket.PingMessage, nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Close :
+func (s *V5WebsocketPrivateService) Close() error {
+	if err := s.connection.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")); err != nil {
+		return err
+	}
+	return nil
 }

--- a/v5_ws_private_test.go
+++ b/v5_ws_private_test.go
@@ -1,0 +1,74 @@
+package bybit
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/hirokisan/bybit/v2/testhelper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrivateWebsocketV5Position(t *testing.T) {
+	respBody := V5WebsocketPrivatePositionResponseContent{
+		Topic:        "position",
+		Id:           "75d86e42f18b23b9ad2c1f10eaffa8bb:18483ff242aca593:0:01",
+		CreationTime: 1677226839837,
+		Data: []V5WebsocketPrivatePositionResponseData{
+			{
+				BustPrice:       "0.10",
+				Category:        "linear",
+				CreatedTime:     "1666729101704",
+				CumRealisedPnl:  "-4.77363636",
+				EntryPrice:      "23780.1",
+				Leverage:        "10",
+				LiqPrice:        "0.10",
+				MarkPrice:       "23782.27",
+				PositionBalance: "2.39085126",
+				PositionIdx:     1,
+				PositionMM:      "0.0000005",
+				PositionIM:      "0.237801",
+				PositionStatus:  "Normal",
+				PositionValue:   "23.7801",
+				RiskId:          1,
+				RiskLimitValue:  "2000000",
+				Side:            "Buy",
+				Size:            "0.001",
+				StopLoss:        "0.00",
+				Symbol:          "BTCUSDT",
+				TakeProfit:      "0.00",
+				TpSlMode:        "Full",
+				TradeMode:       0,
+				AutoAddMargin:   0,
+				TrailingStop:    "0.00",
+				UnrealisedPnl:   "0.00217",
+				UpdatedTime:     "1677226839835",
+			},
+		},
+	}
+	bytesBody, err := json.Marshal(respBody)
+	require.NoError(t, err)
+
+	server, teardown := testhelper.NewWebsocketServer(
+		testhelper.WithWebsocketHandlerOption(V5WebsocketPrivatePath, bytesBody),
+	)
+	defer teardown()
+
+	wsClient := NewTestWebsocketClient().
+		WithBaseURL(server.URL).
+		WithAuth("test", "test")
+
+	svc, err := wsClient.V5().Private()
+	require.NoError(t, err)
+
+	require.NoError(t, svc.Subscribe())
+
+	require.NoError(t, svc.RegisterFuncPosition(func(response V5WebsocketPrivatePositionResponseContent) error {
+		assert.Equal(t, respBody, response)
+		return nil
+	}))
+
+	assert.NoError(t, svc.Run())
+	assert.NoError(t, svc.Ping())
+	assert.NoError(t, svc.Close())
+}


### PR DESCRIPTION
Implement Private V5 for Position.

It's inspired from the private V1 spot for outbound account info, but there are some some tweaks to get a better error handling when the connection is dead, in order to allow a reconnection (see README updates).