### PR TITLE
Name struct on open orders

### DIFF
--- a/v5_order_service.go
+++ b/v5_order_service.go
@@ -139,43 +139,45 @@ type V5GetOpenOrdersResponse struct {
 
 // V5GetOpenOrdersResult :
 type V5GetOpenOrdersResult struct {
-	Category       CategoryV5 `json:"category"`
-	NextPageCursor string     `json:"nextPageCursor"`
-	List           []struct {
-		Symbol             SymbolV5    `json:"symbol"`
-		OrderType          OrderType   `json:"orderType"`
-		OrderLinkID        string      `json:"orderLinkId"`
-		OrderID            string      `json:"orderId"`
-		CancelType         string      `json:"cancelType"`
-		AvgPrice           string      `json:"avgPrice"`
-		StopOrderType      string      `json:"stopOrderType"`
-		LastPriceOnCreated string      `json:"lastPriceOnCreated"`
-		OrderStatus        OrderStatus `json:"orderStatus"`
-		TakeProfit         string      `json:"takeProfit"`
-		CumExecValue       string      `json:"cumExecValue"`
-		TriggerDirection   int         `json:"triggerDirection"`
-		IsLeverage         string      `json:"isLeverage"`
-		RejectReason       string      `json:"rejectReason"`
-		Price              string      `json:"price"`
-		OrderIv            string      `json:"orderIv"`
-		CreatedTime        string      `json:"createdTime"`
-		TpTriggerBy        string      `json:"tpTriggerBy"`
-		PositionIdx        int         `json:"positionIdx"`
-		TimeInForce        TimeInForce `json:"timeInForce"`
-		LeavesValue        string      `json:"leavesValue"`
-		UpdatedTime        string      `json:"updatedTime"`
-		Side               Side        `json:"side"`
-		TriggerPrice       string      `json:"triggerPrice"`
-		CumExecFee         string      `json:"cumExecFee"`
-		LeavesQty          string      `json:"leavesQty"`
-		SlTriggerBy        string      `json:"slTriggerBy"`
-		CloseOnTrigger     bool        `json:"closeOnTrigger"`
-		CumExecQty         string      `json:"cumExecQty"`
-		ReduceOnly         bool        `json:"reduceOnly"`
-		Qty                string      `json:"qty"`
-		StopLoss           string      `json:"stopLoss"`
-		TriggerBy          TriggerBy   `json:"triggerBy"`
-	} `json:"list"`
+	Category       CategoryV5       `json:"category"`
+	NextPageCursor string           `json:"nextPageCursor"`
+	List           []V5GetOpenOrder `json:"list"`
+}
+
+type V5GetOpenOrder struct {
+	Symbol             SymbolV5    `json:"symbol"`
+	OrderType          OrderType   `json:"orderType"`
+	OrderLinkID        string      `json:"orderLinkId"`
+	OrderID            string      `json:"orderId"`
+	CancelType         string      `json:"cancelType"`
+	AvgPrice           string      `json:"avgPrice"`
+	StopOrderType      string      `json:"stopOrderType"`
+	LastPriceOnCreated string      `json:"lastPriceOnCreated"`
+	OrderStatus        OrderStatus `json:"orderStatus"`
+	TakeProfit         string      `json:"takeProfit"`
+	CumExecValue       string      `json:"cumExecValue"`
+	TriggerDirection   int         `json:"triggerDirection"`
+	IsLeverage         string      `json:"isLeverage"`
+	RejectReason       string      `json:"rejectReason"`
+	Price              string      `json:"price"`
+	OrderIv            string      `json:"orderIv"`
+	CreatedTime        string      `json:"createdTime"`
+	TpTriggerBy        string      `json:"tpTriggerBy"`
+	PositionIdx        int         `json:"positionIdx"`
+	TimeInForce        TimeInForce `json:"timeInForce"`
+	LeavesValue        string      `json:"leavesValue"`
+	UpdatedTime        string      `json:"updatedTime"`
+	Side               Side        `json:"side"`
+	TriggerPrice       string      `json:"triggerPrice"`
+	CumExecFee         string      `json:"cumExecFee"`
+	LeavesQty          string      `json:"leavesQty"`
+	SlTriggerBy        string      `json:"slTriggerBy"`
+	CloseOnTrigger     bool        `json:"closeOnTrigger"`
+	CumExecQty         string      `json:"cumExecQty"`
+	ReduceOnly         bool        `json:"reduceOnly"`
+	Qty                string      `json:"qty"`
+	StopLoss           string      `json:"stopLoss"`
+	TriggerBy          TriggerBy   `json:"triggerBy"`
 }
 
 // GetOpenOrders :


### PR DESCRIPTION
Unnamed struct makes it currently hard to aggregate open orders (linear and inverse or even between symbols / settle coins, as symbols or settle coins is a required param)