### PR TITLE
fix: update v5 wss public ping heartbeat 2

### DIFF
--- a/v5_ws_private.go
+++ b/v5_ws_private.go
@@ -229,10 +229,7 @@ func (s *V5WebsocketPrivateService) Run() error {
 
 // Ping :
 func (s *V5WebsocketPrivateService) Ping() error {
-	if err := s.writeMessage(websocket.PingMessage, nil); err != nil {
-		return err
-	}
-	if err := s.writeMessage(websocket.TextMessage, []byte(`{"op":"ping"}`)); err != nil {
+	if err := s.writeMessage(websocket.PingMessage, []byte(`{"op":"ping"}`)); err != nil {
 		return err
 	}
 	return nil

--- a/v5_ws_private.go
+++ b/v5_ws_private.go
@@ -229,6 +229,9 @@ func (s *V5WebsocketPrivateService) Run() error {
 
 // Ping :
 func (s *V5WebsocketPrivateService) Ping() error {
+	if err := s.writeMessage(websocket.PingMessage, nil); err != nil {
+		return err
+	}
 	if err := s.writeMessage(websocket.TextMessage, []byte(`{"op":"ping"}`)); err != nil {
 		return err
 	}

--- a/v5_ws_public.go
+++ b/v5_ws_public.go
@@ -234,10 +234,7 @@ func (s *V5WebsocketPublicService) Run() error {
 
 // Ping :
 func (s *V5WebsocketPublicService) Ping() error {
-	if err := s.writeMessage(websocket.PingMessage, nil); err != nil {
-		return err
-	}
-	if err := s.writeMessage(websocket.TextMessage, []byte(`{"op":"ping"}`)); err != nil {
+	if err := s.writeMessage(websocket.PingMessage, []byte(`{"op":"ping"}`)); err != nil {
 		return err
 	}
 	return nil

--- a/v5_ws_public.go
+++ b/v5_ws_public.go
@@ -234,6 +234,9 @@ func (s *V5WebsocketPublicService) Run() error {
 
 // Ping :
 func (s *V5WebsocketPublicService) Ping() error {
+	if err := s.writeMessage(websocket.PingMessage, nil); err != nil {
+		return err
+	}
 	if err := s.writeMessage(websocket.TextMessage, []byte(`{"op":"ping"}`)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Surprised to find myself creating an update this soon 😢 

After opening the websocket for some time, I am getting `read tcp (my ip)->13.35.7.96:443: i/o timeout` error for every ping message sent. I tried adding the original `PingMessage` and the connection stabilised afterwards.

While comparing another bybit library written in Python, it seems they are sending both `PingMessage` and ping `TextMessage` as well.

ref: https://github.com/bybit-exchange/pybit/blob/9f3e32d4d771727b6e966cfd748b241ed48a1f6a/pybit/_websocket_stream.py#L236

Can you kindly have a look? Thanks.