### PR TITLE
add sync server time service

### DIFF
--- a/client_service.go
+++ b/client_service.go
@@ -26,6 +26,11 @@ func (c *Client) Spot() SpotServiceI {
 	return &SpotService{c}
 }
 
+// NewTimeService :
+func (c *Client) NewTimeService() TimeServiceI {
+	return &TimeService{c}
+}
+
 // FutureServiceI :
 type FutureServiceI interface {
 	InversePerpetual() FutureInversePerpetualServiceI

--- a/time_service.go
+++ b/time_service.go
@@ -1,0 +1,33 @@
+package bybit
+
+// TimeService :
+type TimeService struct {
+	client *Client
+}
+
+// TimeServiceI :
+type TimeServiceI interface {
+	GetServerTime() (*GetServerTimeResponse, error)
+}
+
+// GetServerTimeResponse :
+type GetServerTimeResponse struct {
+	CommonResponse `json:",inline"`
+	Result         GetServerTimeResult `json:"result"`
+}
+
+type GetServerTimeResult struct {
+	TimeSecond string `json:"timeSecond"`
+	TimeNano   string `json:"timeNano"`
+}
+
+// GetServerTime :
+func (s *TimeService) GetServerTime() (*GetServerTimeResponse, error) {
+	var res GetServerTimeResponse
+
+	if err := s.client.getPublicly("/v3/public/time", nil, &res); err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}

--- a/time_service_test.go
+++ b/time_service_test.go
@@ -1,0 +1,30 @@
+package bybit
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpdateSyncTimeDelta(t *testing.T) {
+	// given
+	c := &Client{}
+	remoteServerTimeRaw := "1688721231460000000"
+	localTimestampNanoseconds := int64(1688721231560000000)
+	expectedNsDelta := int64(100000000)
+	recvWindowMs := int64(5000)
+	nowTimestampMs := time.Now().UnixMilli()
+
+	// when
+	err := c.updateSyncTimeDelta(remoteServerTimeRaw, localTimestampNanoseconds)
+
+	// then
+	require.NoError(t, err)
+	assert.Equal(t, expectedNsDelta, c.syncTimeDeltaNanoSeconds)
+
+	timestampMsDelta := int64(math.Abs(float64(c.getTimestamp()) - float64(nowTimestampMs)))
+	assert.Less(t, timestampMsDelta, recvWindowMs)
+}


### PR DESCRIPTION
Example of a request problem when the local time is not synchronized:

```
10002, invalid request, please check your server timestamp or recv_window param. req_timestamp[1688721030939],server_timestamp[1688721231460],recv_window[5000]
```

Solution: added a service to get server time and a method to synchronize local and server time (delta detection).