### PR TITLE
fix linter issues

### DIFF
--- a/v5_order_service.go
+++ b/v5_order_service.go
@@ -264,7 +264,7 @@ func (s *V5OrderService) GetOpenOrders(param V5GetOpenOrdersParam) (*V5GetOrders
 	var res V5GetOrdersResponse
 
 	if param.Category == "" {
-		return nil, fmt.Errorf("Category needed")
+		return nil, fmt.Errorf("category needed")
 	}
 
 	queryString, err := query.Values(param)
@@ -284,7 +284,7 @@ func (s *V5OrderService) GetHistoryOrders(param V5GetHistoryOrdersParam) (*V5Get
 	var res V5GetOrdersResponse
 
 	if param.Category == "" {
-		return nil, fmt.Errorf("Category needed")
+		return nil, fmt.Errorf("category needed")
 	}
 
 	queryString, err := query.Values(param)

--- a/v5_position_service.go
+++ b/v5_position_service.go
@@ -113,7 +113,7 @@ func (s *V5PositionService) SetLeverage(param V5SetLeverageParam) (*V5SetLeverag
 	var res V5SetLeverageResponse
 
 	if param.Category == "" || param.Symbol == "" || param.BuyLeverage == "" || param.SellLeverage == "" {
-		return nil, fmt.Errorf("Category, Symbol, BuyLeverage and SellLeverage needed")
+		return nil, fmt.Errorf("category, Symbol, BuyLeverage and SellLeverage needed")
 	}
 
 	body, err := json.Marshal(param)
@@ -350,7 +350,7 @@ func (p V5SwitchPositionMarginModeParam) validate() error {
 		return fmt.Errorf("only linear and inverse are supported for category")
 	}
 	if p.Symbol == "" || p.BuyLeverage == "" || p.SellLeverage == "" {
-		return fmt.Errorf("Symbol, BuyLeverage and SellLeverage needed")
+		return fmt.Errorf("symbol, BuyLeverage and SellLeverage needed")
 	}
 	return nil
 }


### PR DESCRIPTION
The error text should not start in upper case. Formality, but so as not to be annoyed by the illumination of the linter.

https://github.com/uber-go/guide/blob/master/style.md#errors