### PR TITLE
change server time response check

### DIFF
--- a/client.go
+++ b/client.go
@@ -422,8 +422,8 @@ func (c *Client) SyncServerTime() error {
 		return fmt.Errorf("get server time: %w", err)
 	}
 
-	if r.RetMsg != "OK" {
-		return fmt.Errorf("get server time: %s", r.RetMsg)
+	if r.Result.TimeNano == "" {
+		return errors.New("server time is empty")
 	}
 
 	return c.updateSyncTimeDelta(r.Result.TimeNano, time.Now().UnixNano())


### PR DESCRIPTION
Such a check would be more appropriate. It turns out that RetMsg may not have an "OK" even if the request succeeded and a result was obtained