### PR TITLE
Fix set-collateral-switch account endpoint for REST API V5

### DIFF
--- a/integrationtest/v5/account/account_test.go
+++ b/integrationtest/v5/account/account_test.go
@@ -63,7 +63,10 @@ func TestGetCollateralInfo(t *testing.T) {
 func TestSetCollateralCoin(t *testing.T) {
 	client := bybit.NewTestClient().WithAuthFromEnv()
 	coins := []bybit.Coin{bybit.CoinBTC}
-	res, err := client.V5().Account().SetCollateralCoin(coins, bybit.CollateralSwitchV5On)
+	res, err := client.V5().Account().SetCollateralCoin(bybit.V5SetCollateralCoinParam{
+		Coin:             bybit.CoinBTC,
+		CollateralSwitch: bybit.CollateralSwitchV5On,
+	})
 	require.NoError(t, err)
 	{
 		goldenFilename := "./testdata/v5-account-set-collateral-coin.json"

--- a/v5_account_service.go
+++ b/v5_account_service.go
@@ -11,7 +11,7 @@ import (
 // V5AccountServiceI :
 type V5AccountServiceI interface {
 	GetWalletBalance(AccountType, []Coin) (*V5GetWalletBalanceResponse, error)
-	SetCollateralCoin([]Coin, CollateralSwitchV5) (*V5SetCollateralCoinResponse, error)
+	SetCollateralCoin(V5SetCollateralCoinParam) (*V5SetCollateralCoinResponse, error)
 	GetCollateralInfo(V5GetCollateralInfoParam) (*V5GetCollateralInfoResponse, error)
 	GetAccountInfo() (*V5GetAccountInfoResponse, error)
 	GetTransactionLog(V5GetTransactionLogParam) (*V5GetTransactionLogResponse, error)
@@ -98,7 +98,12 @@ func (s *V5AccountService) GetWalletBalance(at AccountType, coins []Coin) (*V5Ge
 
 // V5SetCollateralCoinParam :
 type V5SetCollateralCoinParam struct {
-	Coin             Coin               `json:"coin"`
+	// Coin:
+	// You cannot pass multiple coins to query
+	// USDT,USDC cannot be switched off
+	Coin Coin `json:"coin"`
+
+	// CollateralSwitch: CollateralSwitchV5On or CollateralSwitchV5Off
 	CollateralSwitch CollateralSwitchV5 `json:"collateralSwitch"`
 }
 
@@ -109,23 +114,8 @@ type V5SetCollateralCoinResponse struct {
 }
 
 // SetCollateralCoin :
-//
-// coins: USDT,USDC cannot be switched off
-// cs: CollateralSwitchV5On or CollateralSwitchV5Off
-func (s *V5AccountService) SetCollateralCoin(coins []Coin, cs CollateralSwitchV5) (*V5SetCollateralCoinResponse, error) {
+func (s *V5AccountService) SetCollateralCoin(param V5SetCollateralCoinParam) (*V5SetCollateralCoinResponse, error) {
 	var res V5SetCollateralCoinResponse
-
-	param := V5SetCollateralCoinParam{
-		CollateralSwitch: cs,
-	}
-
-	if len(coins) > 0 {
-		var coinsStr []string
-		for _, c := range coins {
-			coinsStr = append(coinsStr, string(c))
-		}
-		param.Coin = Coin(strings.Join(coinsStr, ","))
-	}
 
 	body, err := json.Marshal(param)
 	if err != nil {

--- a/v5_account_service_test.go
+++ b/v5_account_service_test.go
@@ -75,8 +75,10 @@ func TestV5Account_GetWalletBalance(t *testing.T) {
 
 func TestV5Account_SetCollateralCoin(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		coins := make([]Coin, 1)
-		coins[0] = CoinBTC
+		param := V5SetCollateralCoinParam{
+			Coin:             CoinBTC,
+			CollateralSwitch: CollateralSwitchV5On,
+		}
 
 		path := "/v5/account/set-collateral-switch"
 		method := http.MethodPost
@@ -97,7 +99,7 @@ func TestV5Account_SetCollateralCoin(t *testing.T) {
 			WithBaseURL(server.URL).
 			WithAuth("test", "test")
 
-		resp, err := client.V5().Account().SetCollateralCoin(coins, CollateralSwitchV5On)
+		resp, err := client.V5().Account().SetCollateralCoin(param)
 		require.NoError(t, err)
 
 		require.NotNil(t, resp)


### PR DESCRIPTION
Found out that set-collateral-switch is not allowed to request for more than one coin at a time.

Also, for some reason test net does not send errors like main net does about changing USDT,USDC coins or trying to change more than coin at a time (e.g. "BTC,TRX"). Seems like there is no way to cover it with tests now. 
Should we do something with that?