### PR TITLE
refactor(client): add context to access denied errors

### DIFF
--- a/client.go
+++ b/client.go
@@ -100,12 +100,14 @@ func (c *Client) Request(req *http.Request, dst interface{}) error {
 			return err
 		}
 		return nil
+	case resp.StatusCode == http.StatusUnauthorized:
+		return fmt.Errorf("%w: invalid key/secret", ErrAccessDenied)
 	case resp.StatusCode == http.StatusForbidden:
-		return ErrAccessDenied
+		return fmt.Errorf("%w: not permitted", ErrAccessDenied)
 	case resp.StatusCode == http.StatusNotFound:
 		return ErrPathNotFound
 	default:
-		return errors.New("unexpected error")
+		return fmt.Errorf("unexpected status code %d", resp.StatusCode)
 	}
 }
 


### PR DESCRIPTION
Changes:

- status code 401 is mapped to ErrAccessDenied
- default branch returns error `fmt.Errorf("unexpected status code %d", resp.StatusCode)` instead of generic `errors.New("unexpected error")`

Reasoning:

- I had `unexpected error` errors and couldn't figure out why my key/secret pair wasn't working. Turns out I forgot to set address to point to Bybit testnet. Bybit returned status code 401 (my testnet key/secret were invalid for Bybit production environment). `unexpected error` without extra context isn't very helpful in similar cases.