### PR TITLE
feat(order): add marketUnit param to CreateOrder method

### DIFF
--- a/enum.go
+++ b/enum.go
@@ -38,6 +38,16 @@ const (
 	OrderTypeMarket = OrderType("Market")
 )
 
+// The unit for qty when create Spot market orders for UTA account.
+type MarketUnit string
+
+const (
+	// Buy BTCUSDT, then "qty" unit is BTC.
+	MarketUnitBaseCoin = MarketUnit("baseCoin")
+	// Sell BTCUSDT, then "qty" unit is USDT.
+	MarketUnitQuoteCoin = MarketUnit("quoteCoin")
+)
+
 // OrderStatus :
 type OrderStatus string
 

--- a/v5_order_service.go
+++ b/v5_order_service.go
@@ -53,6 +53,7 @@ type V5CreateOrderParam struct {
 	SlLimitPrice          *string           `json:"slLimitPrice,omitempty"`
 	TpOrderType           *OrderType        `json:"tpOrderType,omitempty"`
 	SlOrderType           *OrderType        `json:"slOrderType,omitempty"`
+	MarketUnit            *MarketUnit       `json:"marketUnit,omitempty"` // The unit for qty when create Spot market orders for UTA account.
 }
 
 // V5CreateOrderResponse :


### PR DESCRIPTION
Changes:

- added `MarketUnit` type and constants
- added `MarketUnit` field to `V5CreateOrderParam`

Reasoning:

- `marketUnit` is used to toggle between "quantity in base asset" (BTC in BTCUSDT) and "quantity in quote asset" (USDT in BTCUSDT) when creating spot orders. Defaults are not very intuitive in my opinion. It would be good to be able to change it when creating spot orders.