### PR TITLE
fix: use noop logger by default

### DIFF
--- a/client_web_socket.go
+++ b/client_web_socket.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"time"
@@ -100,7 +99,7 @@ func (c *WebSocketClient) Start(ctx context.Context, executors []WebsocketExecut
 					if IsErrWebsocketClosed(err) {
 						return
 					}
-					log.Println(err)
+					logger.Println(err)
 					return
 				}
 			}
@@ -124,7 +123,7 @@ func (c *WebSocketClient) Start(ctx context.Context, executors []WebsocketExecut
 				}
 			}
 		case <-ctx.Done():
-			log.Println("interrupt")
+			logger.Println("interrupt")
 
 			for _, executor := range executors {
 				if err := executor.Close(); err != nil {

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,26 @@
+package bybit
+
+import (
+	"io"
+	"log"
+)
+
+type Logger interface {
+	Println(values ...any)
+}
+
+var logger Logger = newNoopLogger()
+
+func SetLogger(l Logger) {
+	if l != nil {
+		// Use provided logger.
+		logger = l
+	} else {
+		// Disable logging.
+		logger = newNoopLogger()
+	}
+}
+
+func newNoopLogger() Logger {
+	return log.New(io.Discard, "", log.LstdFlags)
+}

--- a/v5_market_service.go
+++ b/v5_market_service.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 
 	"github.com/google/go-querystring/query"
 )
@@ -305,7 +304,7 @@ func (l *V5GetPremiumIndexPriceKlineList) UnmarshalJSON(data []byte) error {
 		if len(d) != 5 {
 			return errors.New("so far len(items) must be 5, please check it on documents")
 		}
-		log.Println(d)
+		logger.Println(d)
 		*l = append(*l, V5GetPremiumIndexPriceKlineItem{
 			StartTime: d[0].(string),
 			Open:      d[1].(string),

--- a/v5_ws_private.go
+++ b/v5_ws_private.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/signal"
 	"sync"
@@ -156,7 +155,7 @@ func (s *V5WebsocketPrivateService) Start(ctx context.Context, errHandler ErrHan
 				return err
 			}
 		case <-ctx.Done():
-			log.Println("interrupt")
+			logger.Println("interrupt")
 
 			if err := s.Close(); err != nil {
 				return err

--- a/v5_ws_public.go
+++ b/v5_ws_public.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
 	"os"
 	"os/signal"
 	"strings"
@@ -185,7 +184,7 @@ func (s *V5WebsocketPublicService) Start(ctx context.Context, errHandler ErrHand
 				return err
 			}
 		case <-ctx.Done():
-			log.Println("interrupt")
+			logger.Println("interrupt")
 
 			if err := s.Close(); err != nil {
 				return err

--- a/ws_spot_v1_private.go
+++ b/ws_spot_v1_private.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
 	"os"
 	"os/signal"
 	"time"
@@ -190,7 +189,7 @@ func (s *SpotWebsocketV1PrivateService) Start(ctx context.Context) {
 				if IsErrWebsocketClosed(err) {
 					return
 				}
-				log.Println(err)
+				logger.Println(err)
 				return
 			}
 		}
@@ -211,7 +210,7 @@ func (s *SpotWebsocketV1PrivateService) Start(ctx context.Context) {
 				return
 			}
 		case <-ctx.Done():
-			log.Println("interrupt")
+			logger.Println("interrupt")
 
 			if err := s.Close(); err != nil {
 				return

--- a/ws_spot_v1_public_v1.go
+++ b/ws_spot_v1_public_v1.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
 	"os"
 	"os/signal"
 	"time"
@@ -193,7 +192,7 @@ func (s *SpotWebsocketV1PublicV1Service) Start(ctx context.Context) {
 				if IsErrWebsocketClosed(err) {
 					return
 				}
-				log.Println(err)
+				logger.Println(err)
 				return
 			}
 		}
@@ -214,7 +213,7 @@ func (s *SpotWebsocketV1PublicV1Service) Start(ctx context.Context) {
 				return
 			}
 		case <-ctx.Done():
-			log.Println("interrupt")
+			logger.Println("interrupt")
 
 			if err := s.Close(); err != nil {
 				return

--- a/ws_spot_v1_public_v2.go
+++ b/ws_spot_v1_public_v2.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log"
 	"os"
 	"os/signal"
 	"time"
@@ -192,7 +191,7 @@ func (s *SpotWebsocketV1PublicV2Service) Start(ctx context.Context) {
 				if IsErrWebsocketClosed(err) {
 					return
 				}
-				log.Println(err)
+				logger.Println(err)
 				return
 			}
 		}
@@ -213,7 +212,7 @@ func (s *SpotWebsocketV1PublicV2Service) Start(ctx context.Context) {
 				return
 			}
 		case <-ctx.Done():
-			log.Println("interrupt")
+			logger.Println("interrupt")
 
 			if err := s.Close(); err != nil {
 				return


### PR DESCRIPTION
Changes:

- added interface `Logger`
- added global variable `logger`
- added method to change global logger
- replaced all `log` package references with `logger` global variable
- use noop logger by default

Reasoning:

- correct me if I'm wrong, current implementation prints debug data every time certain function is run. This simple PR disables all logging by default, but library users can supply their own logger and turn logging back on.

The solution isn't very flexible or configurable as I tried to keep it as simple as possible.