### PR TITLE
Broker support

### DIFF
--- a/client.go
+++ b/client.go
@@ -32,6 +32,8 @@ type Client struct {
 	key     string
 	secret  string
 
+	referer string
+
 	checkResponseBody        checkResponseBodyFunc
 	syncTimeDeltaNanoSeconds int64
 }
@@ -70,6 +72,12 @@ func (c Client) withCheckResponseBody(f checkResponseBodyFunc) *Client {
 // WithBaseURL :
 func (c *Client) WithBaseURL(url string) *Client {
 	c.baseURL = url
+
+	return c
+}
+
+func (c *Client) WithReferer(referer string) *Client {
+	c.referer = referer
 
 	return c
 }
@@ -123,6 +131,9 @@ func (c *Client) populateSignature(src url.Values) url.Values {
 
 	src.Add("api_key", c.key)
 	src.Add("timestamp", strconv.FormatInt(c.getTimestamp(), 10))
+	if c.referer != "" {
+		src.Add("referer", c.referer)
+	}
 	src.Add("sign", getSignature(src, c.secret))
 
 	return src
@@ -136,6 +147,9 @@ func (c *Client) populateSignatureForBody(src []byte) []byte {
 
 	body["api_key"] = c.key
 	body["timestamp"] = strconv.FormatInt(c.getTimestamp(), 10)
+	if c.referer != "" {
+		body["referer"] = c.referer
+	}
 	body["sign"] = getSignatureForBody(body, c.secret)
 
 	result, err := json.Marshal(body)
@@ -339,6 +353,9 @@ func (c *Client) postV5JSON(path string, body []byte, dst interface{}) error {
 	req.Header.Set("X-BAPI-API-KEY", c.key)
 	req.Header.Set("X-BAPI-TIMESTAMP", strconv.FormatInt(timestamp, 10))
 	req.Header.Set("X-BAPI-SIGN", sign)
+	if c.referer != "" {
+		req.Header.Set("X-Referer", c.referer)
+	}
 
 	if err := c.Request(req, &dst); err != nil {
 		return err

--- a/v5_account_service.go
+++ b/v5_account_service.go
@@ -122,7 +122,7 @@ func (s *V5AccountService) SetCollateralCoin(param V5SetCollateralCoinParam) (*V
 		return nil, err
 	}
 
-	if err := s.client.postJSON("/v5/account/set-collateral-switch", body, &res); err != nil {
+	if err := s.client.postV5JSON("/v5/account/set-collateral-switch", body, &res); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Changes:
- fix set collateral coin depreciated post method usage
- add referer client field, which is used to set Referer request header for The Bybit Exchange Broker Program

Referer header and parameter description is kinda vague. I assume that referer value should be added to URL values before signing request, because there is an example:

> [Assume your Broker ID is "api.Abc" when placing orders. Order request should include "&referer=api.Abc&"](https://www.bybit.com/en/help-center/article/FAQ-API-Brokers-Program)

However, Support told me that X-Referer header has no deal with signing a request, which makes no sense to me, because then order requests might be spoofed by hackers in order to get additional rebates. Am I missing something?

![image](https://github.com/hirokisan/bybit/assets/43965646/3b443cd8-9ef0-4e10-b2a1-0cbee0e16544)

Python library also does not include referer header in calculating sign as I see.

And I am not quite sure how to test this feature either.

Would love to hear other opinions on setting X-Referer before or after signing request.