### PR TITLE
Fix WebSocket data parsing to address omission of category indicators

### DIFF
--- a/v5_client_web_socket_service.go
+++ b/v5_client_web_socket_service.go
@@ -25,6 +25,7 @@ func (s *V5WebsocketService) Public(category CategoryV5) (V5WebsocketPublicServi
 	return &V5WebsocketPublicService{
 		client:              s.client,
 		connection:          c,
+		category:            category,
 		paramOrderBookMap:   make(map[V5WebsocketPublicOrderBookParamKey]func(V5WebsocketPublicOrderBookResponse) error),
 		paramKlineMap:       make(map[V5WebsocketPublicKlineParamKey]func(V5WebsocketPublicKlineResponse) error),
 		paramTickerMap:      make(map[V5WebsocketPublicTickerParamKey]func(V5WebsocketPublicTickerResponse) error),

--- a/v5_ws_public_ticker.go
+++ b/v5_ws_public_ticker.go
@@ -73,6 +73,7 @@ type V5WebsocketPublicTickerResponse struct {
 
 // V5WebsocketPublicTickerData :
 type V5WebsocketPublicTickerData struct {
+	category      CategoryV5
 	LinearInverse *V5WebsocketPublicTickerLinearInverseResult
 	Option        *V5WebsocketPublicTickerOptionResult
 	Spot          *V5WebsocketPublicTickerSpotResult


### PR DESCRIPTION
## Description

This pull request addresses the need for adjustments due to changes in the structure of data updates from bybit's WebSocket service. Previously, certain columns such as `Bid1Price` and `Gamma` were included in updates, serving as indicators for categorizing data as linear, inverse, option, or spot. The omission of these columns in recent updates necessitated a new approach to ensure continued accurate categorization and processing.

## Key Changes

- **Introduction of Category Field**: To facilitate precise processing and categorization of data updates, a category field has been added to the `V5WebsocketPublicService` and `V5WebsocketPublicTickerData` structures.
- **Implementation of Category-based Parsing**: The `UnmarshalJSON` function for data updates has been updated to utilize the newly introduced category field, enabling the appropriate structuring of data based on the update category.
- **Category Setting During Message Processing**: The category is now appropriately set during the processing of WebSocket messages, based on the type of update being handled, to inform subsequent data processing actions.