### PR TITLE
Update v5_asset_service.go

### DIFF
--- a/v5_asset_service.go
+++ b/v5_asset_service.go
@@ -150,8 +150,8 @@ type V5CreateUniversalTransferParam struct {
 	Amount          string        `json:"amount"`
 	FromAccountType AccountTypeV5 `json:"fromAccountType"`
 	ToAccountType   AccountTypeV5 `json:"toAccountType"`
-	FromMemberID    int           `json:"fromMemberID"`
-	ToMemberID      int           `json:"toMemberID"`
+	FromMemberID    int           `json:"fromMemberId"`
+	ToMemberID      int           `json:"toMemberId"`
 }
 
 func (p V5CreateUniversalTransferParam) validate() error {
@@ -167,9 +167,6 @@ func (p V5CreateUniversalTransferParam) validate() error {
 	}
 	if p.Coin == "" || p.FromAccountType == "" || p.ToAccountType == "" {
 		return fmt.Errorf("coin, fromAccountType and toAccountType needed")
-	}
-	if p.FromAccountType == p.ToAccountType {
-		return fmt.Errorf("toAccountType and fromAccountType must differ")
 	}
 	return nil
 }


### PR DESCRIPTION
https://bybit-exchange.github.io/docs/v5/asset/unitransfer

It should be fromMemberId, not fromMemberID (and toMemberId, not toMemberID)

Also, fromAccountType can be equal to toAccountType

e.g you can transfer from one spot subaccount to another spot subaccount