### PR TITLE
Fix and refactor v5 enums

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # bybit
 
-bybit is an bybit client for the Go programming language.
+bybit is a bybit client for the Go programming language.
 
 ## Usage
 

--- a/v5_account_service.go
+++ b/v5_account_service.go
@@ -2,6 +2,7 @@ package bybit
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -10,7 +11,7 @@ import (
 
 // V5AccountServiceI :
 type V5AccountServiceI interface {
-	GetWalletBalance(AccountType, []Coin) (*V5GetWalletBalanceResponse, error)
+	GetWalletBalance(AccountTypeV5, []Coin) (*V5GetWalletBalanceResponse, error)
 	SetCollateralCoin(V5SetCollateralCoinParam) (*V5SetCollateralCoinResponse, error)
 	GetCollateralInfo(V5GetCollateralInfoParam) (*V5GetCollateralInfoResponse, error)
 	GetAccountInfo() (*V5GetAccountInfoResponse, error)
@@ -69,12 +70,17 @@ type V5WalletBalanceList struct {
 
 // GetWalletBalance :
 //
-// at: UNIFIED or CONTRACT
+// at: UNIFIED, CONTRACT, SPOT
 //
 // coin:
 // If not passed, it returns non-zero asset info
 // You can pass multiple coins to query, separated by comma. "USDT,USDC".
-func (s *V5AccountService) GetWalletBalance(at AccountType, coins []Coin) (*V5GetWalletBalanceResponse, error) {
+func (s *V5AccountService) GetWalletBalance(at AccountTypeV5, coins []Coin) (*V5GetWalletBalanceResponse, error) {
+	switch at {
+	case AccountTypeV5UNIFIED, AccountTypeV5CONTRACT, AccountTypeV5SPOT:
+	default:
+		return nil, fmt.Errorf("wrong account type")
+	}
 	var (
 		res   V5GetWalletBalanceResponse
 		query = make(url.Values)

--- a/v5_account_service_test.go
+++ b/v5_account_service_test.go
@@ -65,7 +65,7 @@ func TestV5Account_GetWalletBalance(t *testing.T) {
 			WithBaseURL(server.URL).
 			WithAuth("test", "test")
 
-		resp, err := client.V5().Account().GetWalletBalance(AccountTypeUnified, nil)
+		resp, err := client.V5().Account().GetWalletBalance(AccountTypeV5UNIFIED, nil)
 		require.NoError(t, err)
 
 		require.NotNil(t, resp)

--- a/v5_asset_service.go
+++ b/v5_asset_service.go
@@ -582,9 +582,9 @@ func (s *V5AssetService) GetCoinInfo(param V5GetCoinInfoParam) (*V5GetCoinInfoRe
 
 // V5GetAllCoinsBalanceParam :
 type V5GetAllCoinsBalanceParam struct {
-	AccountType AccountType `url:"accountType"`
-	MemberID    string      `url:"memberId,omitempty"`
-	WithBonus   string      `url:"withBonus,omitempty"`
+	AccountType AccountTypeV5 `url:"accountType"`
+	MemberID    string        `url:"memberId,omitempty"`
+	WithBonus   string        `url:"withBonus,omitempty"`
 	Coins       []Coin
 }
 
@@ -597,7 +597,7 @@ type V5GetAllCoinsBalanceResponse struct {
 // V5GetAllCoinsBalanceResult :
 type V5GetAllCoinsBalanceResult struct {
 	MemberID    string                         `json:"memberId"`
-	AccountType AccountType                    `json:"accountType"`
+	AccountType AccountTypeV5                  `json:"accountType"`
 	Balance     []*V5GetAllCoinsBalanceBalance `json:"balance"`
 }
 
@@ -649,12 +649,12 @@ type V5WithdrawParam struct {
 	Amount    string `json:"amount"`
 	Timestamp int64  `json:"timestamp"`
 
-	Chain       *string      `json:"chain,omitempty"`
-	Tag         *string      `json:"tag,omitempty"`
-	ForceChain  *bool        `json:"forceChain,omitempty"`
-	AccountType *AccountType `json:"accountType,omitempty"`
-	FeeType     *int         `json:"feeType,omitempty"`
-	RequestID   *string      `json:"requestId,omitempty"`
+	Chain       *string        `json:"chain,omitempty"`
+	Tag         *string        `json:"tag,omitempty"`
+	ForceChain  *bool          `json:"forceChain,omitempty"`
+	AccountType *AccountTypeV5 `json:"accountType,omitempty"`
+	FeeType     *int           `json:"feeType,omitempty"`
+	RequestID   *string        `json:"requestId,omitempty"`
 }
 
 func (s *V5AssetService) Withdraw(param V5WithdrawParam) (*V5WithdrawResponse, error) {

--- a/v5_asset_service_test.go
+++ b/v5_asset_service_test.go
@@ -837,7 +837,7 @@ func TestV5Asset_Withdraw(t *testing.T) {
 			Amount:      "24",
 			Timestamp:   1672196561407,
 			ForceChain:  testhelper.Ptr(true),
-			AccountType: testhelper.Ptr(AccountTypeFunding),
+			AccountType: testhelper.Ptr(AccountTypeV5FUND),
 			FeeType:     testhelper.Ptr(0),
 		}
 
@@ -877,7 +877,7 @@ func TestV5Asset_Withdraw(t *testing.T) {
 			Amount:      "24",
 			Timestamp:   1672196561407,
 			ForceChain:  testhelper.Ptr(true),
-			AccountType: testhelper.Ptr(AccountTypeFunding),
+			AccountType: testhelper.Ptr(AccountTypeV5FUND),
 			FeeType:     testhelper.Ptr(0),
 		}
 

--- a/v5_enum.go
+++ b/v5_enum.go
@@ -1,14 +1,5 @@
 package bybit
 
-// AccountType :
-type AccountType string
-
-const (
-	AccountTypeUnified AccountType = "UNIFIED"
-	AccountTypeNormal  AccountType = "CONTRACT"
-	AccountTypeFunding AccountType = "FUND"
-)
-
 // MarginMode :
 type MarginMode string
 
@@ -189,12 +180,26 @@ type ExecTypeV5 string
 const (
 	// ExecTypeV5Trade :
 	ExecTypeV5Trade = ExecTypeV5("Trade")
-	// ExecTypeV5BustTrade :
+	// ExecTypeV5AdlTrade : Auto-Deleveraging
+	// https://www.bybit.com/en/help-center/article/Auto-Deleveraging-ADL
+	ExecTypeV5AdlTrade = ExecTypeV5("AdlTrade")
+	// ExecTypeV5Funding : Funding Fee
+	// https://www.bybit.com/en/help-center/article/Introduction-to-Funding-Rate
+	ExecTypeV5Funding = ExecTypeV5("Funding")
+	// ExecTypeV5BustTrade : Takeover liquidation
 	ExecTypeV5BustTrade = ExecTypeV5("BustTrade")
+	// ExecTypeV5Delivery : USDC futures delivery; Position closed by contract delisted
+	ExecTypeV5Delivery = ExecTypeV5("Delivery")
 	// ExecTypeV5SessionSettlePnL :
 	ExecTypeV5SessionSettlePnL = ExecTypeV5("SessionSettlePnL")
 	// ExecTypeV5Settle :
 	ExecTypeV5Settle = ExecTypeV5("Settle")
+	// ExecTypeV5BlockTrade :
+	ExecTypeV5BlockTrade = ExecTypeV5("BlockTrade")
+	// ExecTypeV5MovePosition :
+	ExecTypeV5MovePosition = ExecTypeV5("MovePosition")
+	// ExecTypeV5UNKNOWN : May be returned by a classic account. Cannot query by this type
+	ExecTypeV5UNKNOWN = ExecTypeV5("UNKNOWN")
 )
 
 // TransferStatusV5 :
@@ -213,17 +218,26 @@ const (
 type AccountTypeV5 string
 
 const (
-	// AccountTypeV5CONTRACT :
+	// AccountTypeV5CONTRACT
+	// Classic: Derivatives Account
+	// UTA: 	Inverse Derivatives Account
 	AccountTypeV5CONTRACT = AccountTypeV5("CONTRACT")
-	// AccountTypeV5SPOT :
+	// AccountTypeV5SPOT
+	// Classic: Spot Account
 	AccountTypeV5SPOT = AccountTypeV5("SPOT")
-	// AccountTypeV5INVESTMENT :
+	// AccountTypeV5INVESTMENT
+	// Classic: ByFi Account
+	// Deprecated: this service is now offline
 	AccountTypeV5INVESTMENT = AccountTypeV5("INVESTMENT")
-	// AccountTypeV5OPTION :
+	// AccountTypeV5OPTION
+	// Classic: USDC Derivatives
 	AccountTypeV5OPTION = AccountTypeV5("OPTION")
-	// AccountTypeV5UNIFIED :
+	// AccountTypeV5UNIFIED
+	// UTA: Unified Trading Account
 	AccountTypeV5UNIFIED = AccountTypeV5("UNIFIED")
-	// AccountTypeV5FUND :
+	// AccountTypeV5FUND
+	// Classic: Funding Account
+	// UTA: 	Funding Account
 	AccountTypeV5FUND = AccountTypeV5("FUND")
 )
 
@@ -234,9 +248,12 @@ const (
 	// UnifiedMarginStatusRegular : Regular account
 	UnifiedMarginStatusRegular = UnifiedMarginStatus(1)
 	// UnifiedMarginStatusUnifiedMargin : Unified margin account, it only trades linear perpetual and options.
+	// Deprecated: Is not used anymore - Please ignore
 	UnifiedMarginStatusUnifiedMargin = UnifiedMarginStatus(2)
 	// UnifiedMarginStatusUnifiedTrade : Unified trade account, it can trade linear perpetual, options and spot
 	UnifiedMarginStatusUnifiedTrade = UnifiedMarginStatus(3)
+	// UnifiedMarginStatusUTAPro : UTA Pro, the pro version of Unified trade account
+	UnifiedMarginStatusUTAPro = UnifiedMarginStatus(4)
 )
 
 // TransactionLogTypeV5 :

--- a/v5_ws_private_wallet.go
+++ b/v5_ws_private_wallet.go
@@ -70,7 +70,7 @@ type V5WebsocketPrivateWalletData struct {
 	TotalPerpUPL           string                         `json:"totalPerpUPL"`
 	TotalInitialMargin     string                         `json:"totalInitialMargin"`
 	TotalMaintenanceMargin string                         `json:"totalMaintenanceMargin"`
-	AccountType            AccountType                    `json:"accountType"`
+	AccountType            AccountTypeV5                  `json:"accountType"`
 	Coins                  []V5WebsocketPrivateWalletCoin `json:"coin"`
 }
 


### PR DESCRIPTION
Changes to be made:
- fix: update UnifiedMarginStatus enums with relevant information;
- fix: disambiguate AccountType and AccountTypeV5 enums leaving only AccountTypeV5;
- fix: add missing ExecTypes;
- fix: README.md grammar typo;
- feature: add account type check on v5 account service GetWalletBalance endpoint;
- feature: provide ExecTypeV5 with detailed commentaries.