### PR TITLE
WS write deadline for v5 public

### DIFF
--- a/v5_ws_public.go
+++ b/v5_ws_public.go
@@ -148,6 +148,7 @@ func (s *V5WebsocketPublicService) Start(ctx context.Context, errHandler ErrHand
 		defer s.connection.Close()
 
 		_ = s.connection.SetReadDeadline(time.Now().Add(60 * time.Second))
+		_ = s.connection.SetWriteDeadline(time.Now().Add(60 * time.Second))
 		s.connection.SetPongHandler(func(string) error {
 			_ = s.connection.SetReadDeadline(time.Now().Add(60 * time.Second))
 			return nil


### PR DESCRIPTION
Hi,
I would like to suggest adding a write deadline for the WebSocket.

When my app encounters network issues while attempting to write to the WebSocket, it gets stuck. A timeout feature would allow me to implement some restart procedures in those situations.
