### PR TITLE
feat: add v5 public SubscribeTickers

### DIFF
--- a/v5_ws_public.go
+++ b/v5_ws_public.go
@@ -35,6 +35,11 @@ type V5WebsocketPublicServiceI interface {
 		func(V5WebsocketPublicTickerResponse) error,
 	) (func() error, error)
 
+	SubscribeTickers(
+		[]V5WebsocketPublicTickerParamKey,
+		func(V5WebsocketPublicTickerResponse) error,
+	) (func() error, error)
+
 	SubscribeTrade(
 		V5WebsocketPublicTradeParamKey,
 		func(V5WebsocketPublicTradeResponse) error,


### PR DESCRIPTION
Referring to:
https://bybit-exchange.github.io/docs/v5/ws/connect#public-channel---args-limits

You can pass several arguments to subscribe to several tickers at once in one ws connection. This allows you to save connections and not run into limits.