### PR TITLE
Add slippage tolerance parameters support for market orders

### DIFF
--- a/v5_enum.go
+++ b/v5_enum.go
@@ -338,6 +338,16 @@ const (
 	CopyTradingSupportNormalOnly = CopyTradingSupport("normalOnly")
 )
 
+// SlippageToleranceType : Slippage tolerance type for market orders
+type SlippageToleranceType string
+
+const (
+	// SlippageToleranceTypeTickSize : The highest price of Buy order = ask1 + slippageTolerance x tickSize; the lowest price of Sell order = bid1 - slippageTolerance x tickSize
+	SlippageToleranceTypeTickSize = SlippageToleranceType("TickSize")
+	// SlippageToleranceTypePercent : The highest price of Buy order = ask1 x (1 + slippageTolerance x 0.01); the lowest price of Sell order = bid1 x (1 - slippageTolerance x 0.01)
+	SlippageToleranceTypePercent = SlippageToleranceType("Percent")
+)
+
 // CollateralSwitchV5 :
 type CollateralSwitchV5 string
 

--- a/v5_order_service.go
+++ b/v5_order_service.go
@@ -30,30 +30,32 @@ type V5CreateOrderParam struct {
 	OrderType OrderType  `json:"orderType"`
 	Qty       string     `json:"qty"`
 
-	IsLeverage            *IsLeverage       `json:"isLeverage,omitempty"`
-	Price                 *string           `json:"price,omitempty"`
-	TriggerDirection      *TriggerDirection `json:"triggerDirection,omitempty"`
-	OrderFilter           *OrderFilter      `json:"orderFilter,omitempty"` // If not passed, Order by default
-	TriggerPrice          *string           `json:"triggerPrice,omitempty"`
-	TriggerBy             *TriggerBy        `json:"triggerBy,omitempty"`
-	OrderIv               *string           `json:"orderIv,omitempty"`     // option only.
-	TimeInForce           *TimeInForce      `json:"timeInForce,omitempty"` // If not passed, GTC is used by default
-	PositionIdx           *PositionIdx      `json:"positionIdx,omitempty"` // Under hedge-mode, this param is required
-	OrderLinkID           *string           `json:"orderLinkId,omitempty"`
-	TakeProfit            *string           `json:"takeProfit,omitempty"`
-	StopLoss              *string           `json:"stopLoss,omitempty"`
-	TpTriggerBy           *TriggerBy        `json:"tpTriggerBy,omitempty"`
-	SlTriggerBy           *TriggerBy        `json:"slTriggerBy,omitempty"`
-	ReduceOnly            *bool             `json:"reduce_only,omitempty"`
-	CloseOnTrigger        *bool             `json:"closeOnTrigger,omitempty"`
-	SmpType               *string           `json:"smpType,omitempty"`
-	MarketMakerProtection *bool             `json:"mmp,omitempty"` // option only
-	TpSlMode              *TpSlMode         `json:"tpslMode,omitempty"`
-	TpLimitPrice          *string           `json:"tpLimitPrice,omitempty"`
-	SlLimitPrice          *string           `json:"slLimitPrice,omitempty"`
-	TpOrderType           *OrderType        `json:"tpOrderType,omitempty"`
-	SlOrderType           *OrderType        `json:"slOrderType,omitempty"`
-	MarketUnit            *MarketUnit       `json:"marketUnit,omitempty"` // The unit for qty when create Spot market orders for UTA account.
+	IsLeverage            *IsLeverage            `json:"isLeverage,omitempty"`
+	Price                 *string                `json:"price,omitempty"`
+	TriggerDirection      *TriggerDirection      `json:"triggerDirection,omitempty"`
+	OrderFilter           *OrderFilter           `json:"orderFilter,omitempty"` // If not passed, Order by default
+	TriggerPrice          *string                `json:"triggerPrice,omitempty"`
+	TriggerBy             *TriggerBy             `json:"triggerBy,omitempty"`
+	OrderIv               *string                `json:"orderIv,omitempty"`     // option only.
+	TimeInForce           *TimeInForce           `json:"timeInForce,omitempty"` // If not passed, GTC is used by default
+	PositionIdx           *PositionIdx           `json:"positionIdx,omitempty"` // Under hedge-mode, this param is required
+	OrderLinkID           *string                `json:"orderLinkId,omitempty"`
+	TakeProfit            *string                `json:"takeProfit,omitempty"`
+	StopLoss              *string                `json:"stopLoss,omitempty"`
+	TpTriggerBy           *TriggerBy             `json:"tpTriggerBy,omitempty"`
+	SlTriggerBy           *TriggerBy             `json:"slTriggerBy,omitempty"`
+	ReduceOnly            *bool                  `json:"reduce_only,omitempty"`
+	CloseOnTrigger        *bool                  `json:"closeOnTrigger,omitempty"`
+	SmpType               *string                `json:"smpType,omitempty"`
+	MarketMakerProtection *bool                  `json:"mmp,omitempty"` // option only
+	TpSlMode              *TpSlMode              `json:"tpslMode,omitempty"`
+	TpLimitPrice          *string                `json:"tpLimitPrice,omitempty"`
+	SlLimitPrice          *string                `json:"slLimitPrice,omitempty"`
+	TpOrderType           *OrderType             `json:"tpOrderType,omitempty"`
+	SlOrderType           *OrderType             `json:"slOrderType,omitempty"`
+	MarketUnit            *MarketUnit            `json:"marketUnit,omitempty"`            // The unit for qty when create Spot market orders for UTA account.
+	SlippageToleranceType *SlippageToleranceType `json:"slippageToleranceType,omitempty"` // Slippage tolerance type for market order, TickSize or Percent
+	SlippageTolerance     *string                `json:"slippageTolerance,omitempty"`     // Slippage tolerance value
 }
 
 // V5CreateOrderResponse :
@@ -231,39 +233,41 @@ type V5GetOrdersResult struct {
 }
 
 type V5GetOrder struct {
-	Symbol             SymbolV5    `json:"symbol"`
-	OrderType          OrderType   `json:"orderType"`
-	OrderLinkID        string      `json:"orderLinkId"`
-	OrderID            string      `json:"orderId"`
-	CancelType         string      `json:"cancelType"`
-	AvgPrice           string      `json:"avgPrice"`
-	StopOrderType      string      `json:"stopOrderType"`
-	LastPriceOnCreated string      `json:"lastPriceOnCreated"`
-	OrderStatus        OrderStatus `json:"orderStatus"`
-	TakeProfit         string      `json:"takeProfit"`
-	CumExecValue       string      `json:"cumExecValue"`
-	TriggerDirection   int         `json:"triggerDirection"`
-	IsLeverage         string      `json:"isLeverage"`
-	RejectReason       string      `json:"rejectReason"`
-	Price              string      `json:"price"`
-	OrderIv            string      `json:"orderIv"`
-	CreatedTime        string      `json:"createdTime"`
-	TpTriggerBy        string      `json:"tpTriggerBy"`
-	PositionIdx        int         `json:"positionIdx"`
-	TimeInForce        TimeInForce `json:"timeInForce"`
-	LeavesValue        string      `json:"leavesValue"`
-	UpdatedTime        string      `json:"updatedTime"`
-	Side               Side        `json:"side"`
-	TriggerPrice       string      `json:"triggerPrice"`
-	CumExecFee         string      `json:"cumExecFee"`
-	LeavesQty          string      `json:"leavesQty"`
-	SlTriggerBy        string      `json:"slTriggerBy"`
-	CloseOnTrigger     bool        `json:"closeOnTrigger"`
-	CumExecQty         string      `json:"cumExecQty"`
-	ReduceOnly         bool        `json:"reduceOnly"`
-	Qty                string      `json:"qty"`
-	StopLoss           string      `json:"stopLoss"`
-	TriggerBy          TriggerBy   `json:"triggerBy"`
+	Symbol                SymbolV5              `json:"symbol"`
+	OrderType             OrderType             `json:"orderType"`
+	OrderLinkID           string                `json:"orderLinkId"`
+	OrderID               string                `json:"orderId"`
+	CancelType            string                `json:"cancelType"`
+	AvgPrice              string                `json:"avgPrice"`
+	StopOrderType         string                `json:"stopOrderType"`
+	LastPriceOnCreated    string                `json:"lastPriceOnCreated"`
+	OrderStatus           OrderStatus           `json:"orderStatus"`
+	TakeProfit            string                `json:"takeProfit"`
+	CumExecValue          string                `json:"cumExecValue"`
+	TriggerDirection      int                   `json:"triggerDirection"`
+	IsLeverage            string                `json:"isLeverage"`
+	RejectReason          string                `json:"rejectReason"`
+	Price                 string                `json:"price"`
+	OrderIv               string                `json:"orderIv"`
+	CreatedTime           string                `json:"createdTime"`
+	TpTriggerBy           string                `json:"tpTriggerBy"`
+	PositionIdx           int                   `json:"positionIdx"`
+	TimeInForce           TimeInForce           `json:"timeInForce"`
+	LeavesValue           string                `json:"leavesValue"`
+	UpdatedTime           string                `json:"updatedTime"`
+	Side                  Side                  `json:"side"`
+	TriggerPrice          string                `json:"triggerPrice"`
+	CumExecFee            string                `json:"cumExecFee"`
+	LeavesQty             string                `json:"leavesQty"`
+	SlTriggerBy           string                `json:"slTriggerBy"`
+	CloseOnTrigger        bool                  `json:"closeOnTrigger"`
+	CumExecQty            string                `json:"cumExecQty"`
+	ReduceOnly            bool                  `json:"reduceOnly"`
+	Qty                   string                `json:"qty"`
+	StopLoss              string                `json:"stopLoss"`
+	TriggerBy             TriggerBy             `json:"triggerBy"`
+	SlippageToleranceType SlippageToleranceType `json:"slippageToleranceType"`
+	SlippageTolerance     string                `json:"slippageTolerance"`
 }
 
 // GetOpenOrders :

--- a/v5_order_service_test.go
+++ b/v5_order_service_test.go
@@ -49,6 +49,48 @@ func TestV5Order_CreateOrder(t *testing.T) {
 		require.NotNil(t, resp)
 		testhelper.Compare(t, respBody["result"], resp.Result)
 	})
+
+	t.Run("success with slippage tolerance", func(t *testing.T) {
+		slippageToleranceType := SlippageToleranceTypePercent
+		slippageTolerance := "0.5"
+		param := V5CreateOrderParam{
+			Category:              CategoryV5Spot,
+			Symbol:                SymbolV5BTCUSDT,
+			Side:                  SideBuy,
+			OrderType:             OrderTypeMarket,
+			Qty:                   "0.01",
+			SlippageToleranceType: &slippageToleranceType,
+			SlippageTolerance:     &slippageTolerance,
+		}
+
+		path := "/v5/order/create"
+		method := http.MethodPost
+		status := http.StatusOK
+		respBody := map[string]interface{}{
+			"result": map[string]interface{}{
+				"orderId":     "1358868270414852353",
+				"orderLinkId": "1676725721103694",
+			},
+		}
+		bytesBody, err := json.Marshal(respBody)
+		require.NoError(t, err)
+
+		server, teardown := testhelper.NewServer(
+			testhelper.WithHandlerOption(path, method, status, bytesBody),
+		)
+		defer teardown()
+
+		client := NewTestClient().
+			WithBaseURL(server.URL).
+			WithAuth("test", "test")
+
+		resp, err := client.V5().Order().CreateOrder(param)
+		require.NoError(t, err)
+
+		require.NotNil(t, resp)
+		testhelper.Compare(t, respBody["result"], resp.Result)
+	})
+
 	t.Run("authentication required", func(t *testing.T) {
 		price := "10000.0"
 		param := V5CreateOrderParam{


### PR DESCRIPTION
# Add slippage tolerance parameters support for market orders

## Overview
This PR adds support for the slippage tolerance parameters in the Bybit V5 API, allowing users to control acceptable price deviation when creating market orders.

## Changes
- Added `SlippageToleranceType` enum in `v5_enum.go` with `TickSize` and `Percent` values
- Added `SlippageToleranceType` and `SlippageTolerance` fields to the `V5CreateOrderParam` structure
- Added these same fields to the `V5GetOrder` structure for response parsing
- Created tests to verify order creation with slippage tolerance parameters

## Why this is important
Slippage tolerance parameters are essential for traders in volatile markets to control how much price deviation they're willing to accept when executing market orders. This helps prevent orders from executing at unexpected prices during high volatility periods.

## Usage example
```go
// Creating a market order with percent-based slippage tolerance
slippageToleranceType := SlippageToleranceTypePercent
slippageTolerance := "0.5" // 0.5% maximum price deviation
param := V5CreateOrderParam{
    Category:              CategoryV5Spot,
    Symbol:                SymbolV5BTCUSDT,
    Side:                  SideBuy,
    OrderType:             OrderTypeMarket,
    Qty:                   "0.01",
    SlippageToleranceType: &slippageToleranceType,
    SlippageTolerance:     &slippageTolerance,
}
```

### Example Calculations
- For a Buy market order with slippageTolerance=0.5 and slippageToleranceType=Percent:
  - The highest acceptable price = ask1 × (1 + 0.5 × 0.01) = ask1 × 1.005 (0.5% above ask price)

- For a Sell market order with the same parameters:
  - The lowest acceptable price = bid1 × (1 - 0.5 × 0.01) = bid1 × 0.995 (0.5% below bid price)

## Testing
All tests for the new functionality pass successfully, including both compilation and runtime tests.