### PR TITLE
feat: add marginTrading field support for GetInstrumentsInfo API (#205)

### DIFF
--- a/v5_market_service.go
+++ b/v5_market_service.go
@@ -481,6 +481,7 @@ type V5GetInstrumentsInfoSpotItem struct {
 	QuoteCoin     Coin                `json:"quoteCoin"`
 	Innovation    Innovation          `json:"innovation"`
 	Status        InstrumentStatus    `json:"status"`
+	MarginTrading string              `json:"marginTrading"`
 	LotSizeFilter SpotLotSizeFilterV5 `json:"lotSizeFilter"`
 	PriceFilter   SpotPriceFilterV5   `json:"priceFilter"`
 }

--- a/v5_market_service_test.go
+++ b/v5_market_service_test.go
@@ -334,11 +334,12 @@ func TestV5Market_GetInstrumentsInfo(t *testing.T) {
 				"category": "spot",
 				"list": []map[string]interface{}{
 					{
-						"symbol":     "BTCUSDT",
-						"baseCoin":   "BTC",
-						"quoteCoin":  "USDT",
-						"innovation": "0",
-						"status":     "1",
+						"symbol":        "BTCUSDT",
+						"baseCoin":      "BTC",
+						"quoteCoin":     "USDT",
+						"innovation":    "0",
+						"status":        "1",
+						"marginTrading": "utaOnly",
 						"lotSizeFilter": map[string]interface{}{
 							"basePrecision":  "0.000001",
 							"quotePrecision": "0.00000001",


### PR DESCRIPTION
Add missing MarginTrading field to V5GetInstrumentsInfoSpotItem struct to match Bybit API specification. This field indicates margin trading support status for spot symbols.

for: https://github.com/hirokisan/bybit/issues/205